### PR TITLE
Add SystemsModel class

### DIFF
--- a/analysis/required_global_fleet.py
+++ b/analysis/required_global_fleet.py
@@ -1,20 +1,23 @@
 """Analysis to determine the required size of the global fleet."""
 
 import aviation
+from aviation import _engine as engine
 
 passengers_per_year = 5_000_000_000.0
 seats_per_aircraft = 160.0
 flights_per_aircraft_per_day = 3.6
 days_per_year = 366.0
 
-passengers_per_day = aviation.passengers_per_day(
-    passengers_per_year=passengers_per_year, days_per_year=days_per_year
-)
+inputs = {
+    "passengers_per_year": passengers_per_year,
+    "days_per_year": days_per_year,
+    "seats_per_aircraft": seats_per_aircraft,
+    "flights_per_aircraft_per_day": flights_per_aircraft_per_day,
+}
+output = "required_global_fleet"
 
-required_global_fleet = aviation.required_global_fleet(
-    passengers_per_day=passengers_per_day,
-    seats_per_aircraft=seats_per_aircraft,
-    flights_per_aircraft_per_day=flights_per_aircraft_per_day,
-)
+systems_model = engine.SystemsModel(aviation.transforms)
+required_global_fleet = systems_model.evaluate(inputs, output)
+print(f"{required_global_fleet=}")
 
 print(f"{required_global_fleet=:_}")

--- a/src/aviation/__init__.py
+++ b/src/aviation/__init__.py
@@ -8,3 +8,5 @@ Modules:
 __all__ = ("passengers_per_day", "required_global_fleet")
 
 from aviation.fleet import passengers_per_day, required_global_fleet
+
+transforms = (passengers_per_day, required_global_fleet)

--- a/src/aviation/_engine.py
+++ b/src/aviation/_engine.py
@@ -1,0 +1,32 @@
+import collections.abc
+import typing
+
+from aviation._model import Transform
+
+
+class SystemsModel:
+    def __init__(self, transforms: collections.abc.Sequence[Transform[typing.Any, ...]]) -> None:
+        self.transforms = set(transforms)
+
+    def evaluate(self, inputs: dict[str, typing.Any], output: str) -> typing.Any:  # noqa: ANN401
+        # If the requested `output` has already been suppleied as an input then this can just be
+        # returned directly without any need for computation.
+        if output in inputs:
+            return inputs[output]
+        # The requested `output` isn't in `inputs` so it must be the name of a transform in
+        # `self.transforms`. If it is not found in `self.transforms` then there must be an error.
+        for transform in self.transforms:
+            if transform.name == output:
+                break
+        else:
+            message = f"No transform with name `{output}`."
+            raise ValueError(message)
+        # To evaluate the `transform`, argument for all of its parameters are required. If a
+        # parameter's
+        for parameter in transform.parameters:
+            if parameter not in inputs:
+                inputs[parameter] = self.evaluate(inputs, parameter)
+
+        # Evaluate and return the `transform` associated with the passed `output`.
+        arguments = {parameter: inputs[parameter] for parameter in transform.parameters}
+        return transform(**arguments)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,49 @@
+import pytest
+
+import aviation
+from aviation import _engine as engine
+
+
+@pytest.mark.parametrize(
+    ("inputs", "output", "expected"),
+    (
+        ({"passengers_per_year": 5_000_000_000}, "passengers_per_year", 5_000_000_000),
+        ({"required_global_fleet": 25_000}, "required_global_fleet", 25_000),
+        (
+            {"days_per_year": 366.0, "passengers_per_year": 5_000_000_000},
+            "passengers_per_day",
+            13_661_202.18579235,
+        ),
+        (
+            {
+                "passengers_per_day": 13_661_202.18579235,
+                "seats_per_aircraft": 160.0,
+                "flights_per_aircraft_per_day": 3.6,
+            },
+            "required_global_fleet",
+            23717.364905889495,
+        ),
+        (
+            {
+                "days_per_year": 366.0,
+                "passengers_per_year": 5_000_000_000,
+                "seats_per_aircraft": 160.0,
+                "flights_per_aircraft_per_day": 3.6,
+            },
+            "required_global_fleet",
+            23717.364905889495,
+        ),
+    ),
+)
+def test_systems_model_evaluate(
+    systems_model: engine.SystemsModel,
+    inputs: dict[str, float],
+    output: str,
+    expected: float,
+) -> None:
+    assert systems_model.evaluate(inputs, output) == expected
+
+
+@pytest.fixture
+def systems_model() -> engine.SystemsModel:
+    return engine.SystemsModel(aviation.transforms)


### PR DESCRIPTION
This PR adds the SystemsModel class, like the one from [camia-engine](https://github.com/aviation-impact-accelerator/camia-engine), which can be used to define a systems model from transforms and used to evaluate a specific transform as an output from a collection of known inputs.