### PR TITLE
Add demand model

### DIFF
--- a/analysis/required_global_fleet.py
+++ b/analysis/required_global_fleet.py
@@ -1,17 +1,17 @@
 """Analysis to determine the required size of the global fleet."""
 
 import camia_engine as engine
-from camia_model.units import day, year
+from camia_model.units import day
 
 import aviation
 from aviation.units import aircraft, journey, passenger
 
-passengers_per_year = 5_000_000_000.0 * passenger / year
 seats_per_aircraft = 160.0 * passenger / aircraft
 flights_per_aircraft_per_day = 3.6 * journey / (aircraft * day)
-
+modeling_year = list(range(2025, 2051))
 inputs = {
-    "passengers_per_year": passengers_per_year,
+    "demand_change_model": aviation.DemandChangeModel.EXPONENTIAL,
+    "modeling_year": modeling_year,
     "seats_per_aircraft": seats_per_aircraft,
     "flights_per_aircraft_per_day": flights_per_aircraft_per_day,
 }

--- a/docs/aviation.md
+++ b/docs/aviation.md
@@ -2,6 +2,22 @@
 
 This document describes a simple model of global aviation.
 
+```mermaid
+
+    flowchart LR
+        A[passengers_per_year]
+        A --> B[passengers_per_day]
+        B --> C[required_global_fleet]
+        D[seats_per_aircraft] --> C
+        E[flights_per_aircraft_per_day] --> C
+
+    style A fill:#4E6C41,stroke:#85B09A,stroke-width:1px
+    style B fill:#4E6C41,stroke:#85B09A,stroke-width:1px
+    style C fill:#4E6C41,stroke:#85B09A,stroke-width:1px
+    style D fill:#4E6C41,stroke:#85B09A,stroke-width:1px
+    style E fill:#4E6C41,stroke:#85B09A,stroke-width:1px
+```
+
 ## Constants
 
 The following constants are required for the model and are defined below.

--- a/src/aviation/__init__.py
+++ b/src/aviation/__init__.py
@@ -5,8 +5,20 @@ Modules:
         data.
 """
 
-__all__ = ("passengers_per_day", "required_global_fleet")
+__all__ = ("DemandChangeModel", "transforms")
 
+from aviation.demand import (
+    DemandChangeModel,
+    demand_change_model,
+    demand_change_rate,
+    passengers_per_year,
+)
 from aviation.fleet import passengers_per_day, required_global_fleet
 
-transforms = (passengers_per_day, required_global_fleet)
+transforms = (
+    demand_change_model,
+    demand_change_rate,
+    passengers_per_day,
+    passengers_per_year,
+    required_global_fleet,
+)

--- a/src/aviation/demand.py
+++ b/src/aviation/demand.py
@@ -1,0 +1,76 @@
+"""Growth in global demand for aviation."""
+
+__all__ = (
+    "demand_change_rate",
+    "passengers_per_year",
+)
+
+import enum
+import typing
+
+import camia_model as model
+from camia_model.units import DIMENSIONLESS, Quantity, percent, year
+
+from aviation.units import passenger
+
+PASSENGERS_PER_YEAR_IN_2025 = 5_000_000_000.0 * passenger / year
+
+
+@enum.unique
+class DemandChangeModel(enum.Enum):
+    """Different models that can be used for change in demand."""
+
+    CONSTANT = enum.auto()
+    EXPONENTIAL = enum.auto()
+    LINEAR = enum.auto()
+
+
+@model.transform
+def demand_change_model() -> DemandChangeModel:
+    """The model used for demand growth."""
+    return DemandChangeModel.EXPONENTIAL
+
+
+@model.transform
+def demand_change_rate(
+    demand_change_model: DemandChangeModel,
+) -> typing.Annotated[Quantity, percent / year]:
+    """The rate at which passenger demand may change in the future."""
+    match demand_change_model:
+        case DemandChangeModel.EXPONENTIAL:
+            return -2.0 * percent / year
+        case DemandChangeModel.LINEAR:
+            return -1.0 * percent / year
+        case DemandChangeModel.CONSTANT:
+            return 0.0 * percent / year
+
+
+@model.transform.switch(demand_change_model=DemandChangeModel.LINEAR)
+def passengers_per_year(
+    modeling_year: int, demand_change_rate: typing.Annotated[Quantity, percent / year]
+) -> typing.Annotated[Quantity, passenger / year]:
+    """The number of passengers per year globally.
+
+    Args:
+        modeling_year: The year in which the numner of passengers per year globally is projected.
+        demand_change_rate: The rate at which passenger demand may change in the future.
+
+    """
+    years_since_2025 = float(modeling_year - 2025) * year
+    growth_factor = 100.0 * percent + demand_change_rate * years_since_2025
+    return (PASSENGERS_PER_YEAR_IN_2025 * growth_factor).convert_to(passenger / year)
+
+
+@model.transform.switch(demand_change_model=DemandChangeModel.EXPONENTIAL)  # type: ignore[no-redef]
+def passengers_per_year(  # noqa: F811
+    modeling_year: int, demand_change_rate: typing.Annotated[Quantity, percent / year]
+) -> typing.Annotated[Quantity, passenger / year]:
+    """The number of passengers per year globally."""
+    growth_factor = (100.0 * percent + demand_change_rate * 1.0 * year).convert_to(DIMENSIONLESS)
+    return PASSENGERS_PER_YEAR_IN_2025 * growth_factor ** (modeling_year - 2025)
+
+
+@model.transform.switch(demand_change_model=DemandChangeModel.CONSTANT)  # type: ignore[no-redef]
+def passengers_per_year() -> typing.Annotated[Quantity, passenger / year]:  # noqa: F811
+    """The number of passengers per year globally."""
+    return PASSENGERS_PER_YEAR_IN_2025

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -1,0 +1,60 @@
+import typing
+
+import pytest
+import pytest_camia
+from camia_model.units import Quantity, percent, year
+
+from aviation.demand import DemandChangeModel, demand_change_rate, passengers_per_year
+from aviation.units import passenger
+
+
+@pytest.mark.parametrize(
+    ("demand_change_model", "expected_demand_change_rate"),
+    (
+        (DemandChangeModel.EXPONENTIAL, -2.0 * percent / year),
+        (DemandChangeModel.LINEAR, -1.0 * percent / year),
+        (DemandChangeModel.CONSTANT, 0.0 * percent / year),
+    ),
+)
+def test_demand_change_rate(
+    demand_change_model: DemandChangeModel,
+    expected_demand_change_rate: typing.Annotated[Quantity, percent / year],
+) -> None:
+    assert (
+        demand_change_rate(demand_change_model=demand_change_model) == expected_demand_change_rate
+    )
+
+
+@pytest.mark.parametrize(
+    ("context", "modeling_year", "demand_change_rate", "expected_passengers_per_year"),
+    (
+        (
+            {"demand_change_model": DemandChangeModel.EXPONENTIAL},
+            2025,
+            3.0 * percent / year,
+            5_000_000_000.0 * passenger / year,
+        ),
+        (
+            {"demand_change_model": DemandChangeModel.EXPONENTIAL},
+            2025,
+            5.0 * percent / year,
+            5_000_000_000.0 * passenger / year,
+        ),
+        (
+            {"demand_change_model": DemandChangeModel.EXPONENTIAL},
+            2050,
+            -2.0 * percent / year,
+            3_017_323_649.0 * passenger / year,
+        ),
+    ),
+)
+def test_passengers_per_year(
+    context: dict[str, DemandChangeModel],
+    modeling_year: int,
+    demand_change_rate: typing.Annotated[Quantity, percent / year],
+    expected_passengers_per_year: typing.Annotated[Quantity, passenger / year],
+) -> None:
+    with passengers_per_year.context(**context):
+        assert passengers_per_year(modeling_year, demand_change_rate) == pytest_camia.approx(
+            expected_passengers_per_year
+        )


### PR DESCRIPTION
This PR adds a demand model to predict future passengers per year. Three different options are added to model demand which include a constant demand, a linear increase in demand and an exponentially increasing demand.